### PR TITLE
Pin additional dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 keyring==25.5.0
 pyomo==6.6.2
 PySide6==6.5.2
-pandas
+pandas==2.1.4
 numpy==1.24.3
+python-dateutil==2.8.2
+pyodbc==4.0.39
+requests==2.31.0
 snowflake-connector-python==3.3.1
-sqlalchemy
+sqlalchemy==2.0.25


### PR DESCRIPTION
## Summary
- pin pandas and sqlalchemy to specific versions for reproducible installs
- add explicit version requirements for python-dateutil, pyodbc, and requests

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68c84938c1d88333a17aa6b29d5c07e7