### PR TITLE
Handle null client names in customer group box

### DIFF
--- a/scripts/gui/configuration_panel/customer_groupbox.py
+++ b/scripts/gui/configuration_panel/customer_groupbox.py
@@ -93,6 +93,8 @@ class CustomerGroupBox(QWidget):
         """
         self.parent.load_client(client_id)
         client_name = self.data_filter.get_client_name()
+        if pandas.isnull(client_name):
+            client_name = 'None selected'
         new_text = self.groupbox_settings['groupbox_title'] + ': ' + client_name
         self.customer_name_label.setText(new_text)
         self.change_customer_button.setText(self.groupbox_settings['change_customer_button']['label_selected'])


### PR DESCRIPTION
## Summary
- sanitize the client name when loading a customer so the label shows a placeholder when null

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68c850eec2708333b5d5f12f8f7aa5d9