### PR TITLE
Add reset handler for configuration metadata widget

### DIFF
--- a/scripts/gui/configuration_panel/configuration_metadata_group.py
+++ b/scripts/gui/configuration_panel/configuration_metadata_group.py
@@ -112,6 +112,13 @@ class ConfigurationMetaData(DisableableWidget):
         self.group_box.setLayout(vbox)
         self.layout.addWidget(self.group_box)
  
+    def reset(self) -> None:
+        """Rebuild the widget without modifying any data filters."""
+        if self.enabled:
+            self.load_ui()
+        else:
+            self.load_disabled_ui()
+
     def toggle_preferred_state(self) -> None:
         """This function toggles the preferred state for this configuration.
         """        


### PR DESCRIPTION
## Summary
- add a `reset` method to `ConfigurationMetaData` so the metadata panel can rebuild its UI without touching filters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68c85193b9108333bb9cb8a9336e6daa