### PR TITLE
Refresh picklists after loading saved configuration

### DIFF
--- a/scripts/gui/configuration_panel/aggregation_builder_groupbox.py
+++ b/scripts/gui/configuration_panel/aggregation_builder_groupbox.py
@@ -68,7 +68,33 @@ class AggregationBuilderGroupbox(DisableableWidget):
         self.group_box.set_ui(enabled=False, add_disabled_label=True)
         self.layout.addWidget(self.group_box)
 
-    
+
+    def reset(self) -> None:
+        """Rebuild the widget while preserving the current data filter selections."""
+
+        preserved_filters = {}
+        for field_items in self.box_configs.get('fields', []):
+            field_configs = widget_functions.FieldConfigs(field_items)
+            if field_configs.data_field is not None:
+                filter_key = field_configs.data_field
+            elif field_configs.var_name is not None:
+                filter_key = field_configs.var_name
+            else:
+                filter_key = field_configs.label
+            filter_value = self.data_filter.get_filter_value(filter_key)
+            if filter_value is not None:
+                preserved_filters[filter_key] = filter_value
+
+        rebuild_enabled = self.enabled is not False
+        if rebuild_enabled:
+            self.load_ui()
+        else:
+            self.load_disabled_ui()
+
+        for filter_key, filter_value in preserved_filters.items():
+            self.data_filter.set_filter(filter_key, filter_value)
+
+
     def generate_groupbox(self) -> StyledGroupBox:
         """This function generates the groupbox for this widget.
 

--- a/scripts/gui/configuration_panel/configuration_panel.py
+++ b/scripts/gui/configuration_panel/configuration_panel.py
@@ -67,6 +67,7 @@ class ConfigurationPanel(ColoredWidget):
             width=left_width,
             load_client_func=self.load_client,
             undo_changes_func=self.undo_changes,
+            configuration_loaded_func=self.on_configuration_loaded,
             )
         metadata_scroll_area.setWidget(self.metadata_groupbox)
         metadata_scroll_area.setFixedHeight(self.model_configs.get_application_setting('configuration_panel', 'configuration_metadata_box')['height'] - 10)
@@ -127,6 +128,14 @@ class ConfigurationPanel(ColoredWidget):
         self.hlayout.addLayout(rightVboxLayout)
 
         self.setLayout(self.hlayout)
+
+
+    def on_configuration_loaded(self) -> None:
+        """Refresh dependent widgets after a saved configuration is loaded."""
+        self.metadata_groupbox.reset()
+        self.configuration_entry_group.reset()
+        self.data_selection_groupbox.reset()
+        self.aggregation_builder_groupbox.reset()
 
 
     def load_client(self, client_id: str) -> None:
@@ -246,7 +255,8 @@ class ConfigurationPanel(ColoredWidget):
 
     def clear_ui(self) -> None:
         """This function clears the UI for the widget
-        """        
+        """
         self.configuration_entry_group.reset()
         self.metadata_groupbox.reset()
         self.data_selection_groupbox.reset()
+        self.aggregation_builder_groupbox.reset()


### PR DESCRIPTION
## Summary
- add a configuration-loaded callback so the panel can refresh its widgets after importing a saved scenario
- rebuild the aggregation builder group box with its existing selections to repopulate picklists
- trigger the configuration panel group boxes to reset so saved drop-down selections appear again

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'keyring')*

------
https://chatgpt.com/codex/tasks/task_b_68c97fdc6dfc8333bc11c4323061e0be